### PR TITLE
Acquire jwt, make a bid and redirect to stripe

### DIFF
--- a/_layouts/payment.html
+++ b/_layouts/payment.html
@@ -21,5 +21,6 @@ in the future, this page would actually be the payment page, but I think right n
 </pre>
 
 <script src="/assets/js/pay.js" deferred></script>
+<script src="https://js.stripe.com/v3/"></script>
 <script src="https://cdn.auth0.com/js/auth0-spa-js/1.14/auth0-spa-js.production.js"></script>
 

--- a/assets/js/pay.js
+++ b/assets/js/pay.js
@@ -1,4 +1,5 @@
 let auth0 = null;
+let stripe;
 const fetchAuthConfig = () => fetch("/auth_config.json");
 const configureClient = async () => {
   const response = await fetchAuthConfig();
@@ -59,7 +60,9 @@ beforeSend: function (xhr) {
 contentType: 'application/json',
 data: JSON.stringify({"currency":"USD","amount":amountAsCent,"quantity":urlParams.get('qty')}),
 success: async function (result) {
-//get the sessionId to serve up stripe checkout
+	//TODO this should be done earlier
+	stripe = Stripe(result.publishableKey);
+	//get the sessionId to serve up stripe checkout
 	//redirect to stripe checkout page?
 	const stripeResponse = await stripe.redirectToCheckout({
 	  sessionId: result.sessionId,


### PR DESCRIPTION
I fix the JWT token issue, and wire up the initial bid-request.
Bid is now completed and backend returns the following response:

````
{
  "sessionId": "cs_test_c18KqbgbaF5WelYzU9GWviYowB8Pluz4p7Q5XUVlXK4gVagx8awEMW6afZ",
  "cancelUrl": "https://oneweektickets.com/bid/cancel",
  "successUrl": "https://oneweektickets.com/bid/success?session_id={CHECKOUT_SESSION_ID}",
  "publishableKey": "pk_live_51IdefoEwp6z4fR3E9Fe3DPstPyRUMcM4nwqdQYwVix8yxNiarmUpH6TsdiYaRJuMNZ0dEI0Vvyh3fK9D1zAfEGVw00TLIxmvs7"
}
```` 

Once the response is returned it redirects to the checkout. After checkout stripe redirects to the `https://oneweektickets.com/bid/success?`. 

